### PR TITLE
Trigger redeployment of updates to diffpy.org

### DIFF
--- a/products/pdfgetx.html
+++ b/products/pdfgetx.html
@@ -139,7 +139,7 @@ to the licensing page again.</p></li>
 <section id="documentation">
 <h2>Documentation<a class="headerlink" href="#documentation" title="Permalink to this headline">¶</a></h2>
 <section id="version-2-1-1-latest">
-<h3>Version 2.1.1 - latest<a class="headerlink" href="#version-2-1-1-latest" title="Permalink to this headline">¶</a></h3>
+<h3>Version 2.1.1 - Latest<a class="headerlink" href="#version-2-1-1-latest" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p><a class="reference external" href="../doc/pdfgetx/2.1.1/install.html">installation instructions</a></p></li>
 <li><p><a class="reference external" href="../doc/pdfgetx/2.1.1/index.html">user manual</a>,


### PR DESCRIPTION
Inconsequential change of 'latest'->'Latest' in `products/pdfgetx.html` to force a diff to re-commit this branch and trigger a redeployment of the GitHub pages

@sbillinge, this commit is effectively identical to the previous attempt at deploying the recent updates to diffpy.org, however, now we are re-deploying after other [users who reported experiencing the same problem](https://www.reddit.com/r/github/comments/rkka9z/github_pages_deployment_error/) have apparently had the issue addressed and resolved from the GitHub side of things. That is, merge this when you get a chance and hopefully the issue will be resolved for us as well.