### PR TITLE
docs: CMI name update and installation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sphinx sources for the [diffpy.org][site] web page.
 - [Where to Make Changes](#where-to-make-changes)
   - [Adding Citations](#adding-citations)
     - [Adding Publications that Describe a DiffPy Project (the "Reference" Section)](#reference-section-1)
-    - [Adding Other Publications (the "Publication Using DiffPy-CMI" Section)](#reference-section-2)
+    - [Adding Other Publications (the "Publication Using DiffPy.CMI" Section)](#reference-section-2)
 - [New Version of Existing Project](#new-version)
 - [New Project](#publishing-new-project)
 - [Publishing Changes](#publishing-changes)
@@ -107,8 +107,8 @@ you add the reference to the proper section and do so in descending reverse chro
 (i.e., the newest citations should appear at the top of their respective sections).
 
 <a name="reference-section-note">*Note:*</a> In this example, the citation is for a publication 
-which describes a product of the DiffPy-CMI project (namely, PDFgetN3). For publications which 
-describe a component of DiffPy-CMI, we provide a link to download the publication directly from
+which describes a product of the DiffPy.CMI project (namely, PDFgetN3). For publications which 
+describe a component of DiffPy.CMI, we provide a link to download the publication directly from
 the [diffpy.org][site] website. Here, the link is provided via the `|downloadJuhasJac18|` tag
 which is the identifier for another snippet within [abbreviations.txt](https://github.com/diffpy/diffpy.github.io/blob/source/abbreviations.txt#L294) following the definition
 of `|citeJuhasJac18|`, seen here as:
@@ -130,10 +130,10 @@ placed within `pdfgetx`'s documentation directory and referenced accordingly wit
 
 
 <a name="reference-section-2"></a>
-### Adding Other Publications (the "Publication Using DiffPy-CMI" Section)
+### Adding Other Publications (the "Publication Using DiffPy.CMI" Section)
 
-Adding references to publications that do not describe the release/use of a product within the DiffPy-CMI 
-project (e.g., papers which use some component of DiffPy-CMI), we simply provide the usual citation text (with
+Adding references to publications that do not describe the release/use of a product within the DiffPy.CMI 
+project (e.g., papers which use some component of DiffPy.CMI), we simply provide the usual citation text (with
 appropriate DOI link). To add a citation of this type, refer to the information in [Reference Section](#reference-section-1), but
 disregard everything starting at, and following, the [Note](#reference-section-note).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sphinx sources for the [diffpy.org][site] web page.
 - [Where to Make Changes](#where-to-make-changes)
   - [Adding Citations](#adding-citations)
     - [Adding Publications that Describe a DiffPy Project (the "Reference" Section)](#reference-section-1)
-    - [Adding Other Publications (the "Publication Using DiffPy.CMI" Section)](#reference-section-2)
+    - [Adding Other Publications (the "Publication Using diffpy.cmi" Section)](#reference-section-2)
 - [New Version of Existing Project](#new-version)
 - [New Project](#publishing-new-project)
 - [Publishing Changes](#publishing-changes)
@@ -107,8 +107,8 @@ you add the reference to the proper section and do so in descending reverse chro
 (i.e., the newest citations should appear at the top of their respective sections).
 
 <a name="reference-section-note">*Note:*</a> In this example, the citation is for a publication 
-which describes a product of the DiffPy.CMI project (namely, PDFgetN3). For publications which 
-describe a component of DiffPy.CMI, we provide a link to download the publication directly from
+which describes a product of the diffpy.cmi project (namely, PDFgetN3). For publications which 
+describe a component of diffpy.cmi, we provide a link to download the publication directly from
 the [diffpy.org][site] website. Here, the link is provided via the `|downloadJuhasJac18|` tag
 which is the identifier for another snippet within [abbreviations.txt](https://github.com/diffpy/diffpy.github.io/blob/source/abbreviations.txt#L294) following the definition
 of `|citeJuhasJac18|`, seen here as:
@@ -130,10 +130,10 @@ placed within `pdfgetx`'s documentation directory and referenced accordingly wit
 
 
 <a name="reference-section-2"></a>
-### Adding Other Publications (the "Publication Using DiffPy.CMI" Section)
+### Adding Other Publications (the "Publication Using diffpy.cmi" Section)
 
-Adding references to publications that do not describe the release/use of a product within the DiffPy.CMI 
-project (e.g., papers which use some component of DiffPy.CMI), we simply provide the usual citation text (with
+Adding references to publications that do not describe the release/use of a product within the diffpy.cmi 
+project (e.g., papers which use some component of diffpy.cmi), we simply provide the usual citation text (with
 appropriate DOI link). To add a citation of this type, refer to the information in [Reference Section](#reference-section-1), but
 disregard everything starting at, and following, the [Note](#reference-section-note).
 

--- a/_includes/substitutions.rst
+++ b/_includes/substitutions.rst
@@ -1,0 +1,2 @@
+.. define global names and alias here
+.. |diffpycmi| replace:: diffpy.cmi

--- a/_templates/menu01.html
+++ b/_templates/menu01.html
@@ -7,7 +7,7 @@
   <ul class="dropdown-menu menu01"
       role="menu"
       aria-labelledby="dLabelMenu01">
-      <li><a href="{{pathto('products/diffpycmi/index')}}">DiffPy-CMI</a></li>
+      <li><a href="{{pathto('products/diffpycmi/index')}}">DiffPy.CMI</a></li>
       <li><a href="{{pathto('products/xPDFsuite')}}">xPDFsuite</a></li>
       <li><a href="{{pathto('products/pdfgetx')}}">PDFgetX3, PDFgetN3 and PDFgetS3</a></li>
       <li><a href="{{pathto('products/pdfgui')}}">PDFgui</a></li>

--- a/_templates/menu01.html
+++ b/_templates/menu01.html
@@ -7,7 +7,7 @@
   <ul class="dropdown-menu menu01"
       role="menu"
       aria-labelledby="dLabelMenu01">
-      <li><a href="{{pathto('products/diffpycmi/index')}}">DiffPy.CMI</a></li>
+      <li><a href="{{pathto('products/diffpycmi/index')}}">diffpy.cmi</a></li>
       <li><a href="{{pathto('products/xPDFsuite')}}">xPDFsuite</a></li>
       <li><a href="{{pathto('products/pdfgetx')}}">PDFgetX3, PDFgetN3 and PDFgetS3</a></li>
       <li><a href="{{pathto('products/pdfgui')}}">PDFgui</a></li>

--- a/abbreviations.txt
+++ b/abbreviations.txt
@@ -66,7 +66,7 @@
 
 
 .. |DiffPyCMI| replace::
-   :doc:`DiffPy-CMI </products/diffpycmi/index>`
+   :doc:`DiffPy.CMI </products/diffpycmi/index>`
 
 .. |citeShiPRL14| replace:: Chenyang Shi, Majid Beidaghi, Michael
    Naguib, Olha Mashtalir, Yury Gogotsi, and Simon J. L. Billinge,

--- a/abbreviations.txt
+++ b/abbreviations.txt
@@ -66,7 +66,7 @@
 
 
 .. |DiffPyCMI| replace::
-   :doc:`DiffPy.CMI </products/diffpycmi/index>`
+   :doc:`diffpy.cmi </products/diffpycmi/index>`
 
 .. |citeShiPRL14| replace:: Chenyang Shi, Majid Beidaghi, Michael
    Naguib, Olha Mashtalir, Yury Gogotsi, and Simon J. L. Billinge,

--- a/conf.py
+++ b/conf.py
@@ -40,6 +40,11 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
+# The reST default prolog, included at the beginning of every source file.
+rst_prolog = """
+.. include:: _includes/substitutions.rst
+"""
+
 # The master toctree document.
 master_doc = 'index'
 

--- a/products/diffpycmi/LICENSE.txt
+++ b/products/diffpycmi/LICENSE.txt
@@ -14,15 +14,15 @@ Copyright (c) 2014-2019, Brookhaven Science Associates, Brookhaven National
     Laboratory
 
 
-The "DiffPy.CMI" is distributed subject to the following license conditions:
+The "diffpy.cmi" is distributed subject to the following license conditions:
 
 
 SOFTWARE LICENSE AGREEMENT
 
-    Software: DiffPy.CMI
+    Software: diffpy.cmi
 
 
-(1) The "Software", below, refers to the aforementioned DiffPy.CMI (in either
+(1) The "Software", below, refers to the aforementioned diffpy.cmi (in either
 source code, or binary form and accompanying documentation).
 
 Part of the software was derived from the DANSE, ObjCryst++ (with permission),

--- a/products/diffpycmi/LICENSE.txt
+++ b/products/diffpycmi/LICENSE.txt
@@ -14,15 +14,15 @@ Copyright (c) 2014-2019, Brookhaven Science Associates, Brookhaven National
     Laboratory
 
 
-The "DiffPy-CMI" is distributed subject to the following license conditions:
+The "DiffPy.CMI" is distributed subject to the following license conditions:
 
 
 SOFTWARE LICENSE AGREEMENT
 
-    Software: DiffPy-CMI
+    Software: DiffPy.CMI
 
 
-(1) The "Software", below, refers to the aforementioned DiffPy-CMI (in either
+(1) The "Software", below, refers to the aforementioned DiffPy.CMI (in either
 source code, or binary form and accompanying documentation).
 
 Part of the software was derived from the DANSE, ObjCryst++ (with permission),

--- a/products/diffpycmi/cmi_exchange.rst
+++ b/products/diffpycmi/cmi_exchange.rst
@@ -2,9 +2,9 @@ CMI Exchange
 =============
 
 The `CMI Exchange`_ is a collection of community developed scripts,
-functions, and IPython plugins that make use of the DiffPy.CMI
-framework. If you are new to DiffPy.CMI it is a great place to get
-started.  If you've been working with DiffPy.CMI for a while and feel
+functions, and IPython plugins that make use of the |diffpycmi|
+framework. If you are new to |diffpycmi| it is a great place to get
+started.  If you've been working with |diffpycmi| for a while and feel
 that others would benefit from seeing your code please contribute!
 
 .. _cmi exchange: https://github.com/diffpy/cmi_exchange#cmi-exchange

--- a/products/diffpycmi/cmi_exchange.rst
+++ b/products/diffpycmi/cmi_exchange.rst
@@ -2,9 +2,9 @@ CMI Exchange
 =============
 
 The `CMI Exchange`_ is a collection of community developed scripts,
-functions, and IPython plugins that make use of the DiffPy-CMI
-framework. If you are new to DiffPy-CMI it is a great place to get
-started.  If you've been working with DiffPy-CMI for a while and feel
+functions, and IPython plugins that make use of the DiffPy.CMI
+framework. If you are new to DiffPy.CMI it is a great place to get
+started.  If you've been working with DiffPy.CMI for a while and feel
 that others would benefit from seeing your code please contribute!
 
 .. _cmi exchange: https://github.com/diffpy/cmi_exchange#cmi-exchange

--- a/products/diffpycmi/contents.rst
+++ b/products/diffpycmi/contents.rst
@@ -1,9 +1,9 @@
 .. _contents:
 
-DiffPy.CMI Contents
+|diffpycmi| Contents
 ===================
 
-The DiffPy.CMI release includes Python and C++ libraries developed by
+The |diffpycmi| release includes Python and C++ libraries developed by
 the DiffPy team as well as external libraries necessary for functionality.
 
 Libraries developed by the DiffPy team

--- a/products/diffpycmi/contents.rst
+++ b/products/diffpycmi/contents.rst
@@ -1,9 +1,9 @@
 .. _contents:
 
-DiffPy-CMI Contents
+DiffPy.CMI Contents
 ===================
 
-The DiffPy-CMI release includes Python and C++ libraries developed by
+The DiffPy.CMI release includes Python and C++ libraries developed by
 the DiffPy team as well as external libraries necessary for functionality.
 
 Libraries developed by the DiffPy team

--- a/products/diffpycmi/contributecode.rst
+++ b/products/diffpycmi/contributecode.rst
@@ -1,7 +1,7 @@
 How to Contribute Code
 ======================
 
-The DiffPy.CMI bundle consists of the following projects, all hosted on
+The |diffpycmi| bundle consists of the following projects, all hosted on
 github.  To contribute code simply fork the project you'd like to work
 on and issue a pull request.
 

--- a/products/diffpycmi/contributecode.rst
+++ b/products/diffpycmi/contributecode.rst
@@ -1,7 +1,7 @@
 How to Contribute Code
 ======================
 
-The DiffPy-CMI bundle consists of the following projects, all hosted on
+The DiffPy.CMI bundle consists of the following projects, all hosted on
 github.  To contribute code simply fork the project you'd like to work
 on and issue a pull request.
 

--- a/products/diffpycmi/index.rst
+++ b/products/diffpycmi/index.rst
@@ -168,11 +168,14 @@ What next?
 Tutorials
 =========
 
-* Worked examples and experimental data from the book are freely available at our
+* A step-by-step tutorial on using diffpy.cmi for PDF analysis is available at the documentation site for
+  ``DiffPy.CMI`` -- https://www.diffpy.org/diffpy.cmi/tutorials/index.html.
+
+* Worked examples and experimental data from the book *Atomic Pair Distribution Function Analysis: A Primer* are freely available at our
   `GitHub repository <https://github.com/Billingegroup/pdfttp_data>`_.
 
 * ADD2019 school and conference --
-  https://github.com/diffpy/add2019-diffpy-cmi
+  https://github.com/diffpy/add2019-diffpy-cmi.
 
 Documentation
 =============

--- a/products/diffpycmi/index.rst
+++ b/products/diffpycmi/index.rst
@@ -1,26 +1,19 @@
 ##########
-DiffPy-CMI
+DiffPy.CMI
 ##########
 
-DiffPy-CMI is our complex modeling framework. It is a highly flexible
-library of Python modules for robust modeling of nanostructures in
-crystals, nanomaterials, and amorphous materials.
+Diffpy.cmi is designed as an extensible complex modeling infrastructure. 
+Users and developers can readily integrate novel data types and constraints 
+into custom workflows. While widely used for advanced analysis of structural 
+data, the framework is general and can be applied to any problem where model 
+parameters are refined to fit calculated quantities to data.
 
-The software provides functionality for storage and manipulation of
-structure data and calculation of structure-based quantities, such as
-PDF, SAS, bond valence sums, atom overlaps, bond lengths, and
-coordinations. Most importantly the DiffPy-CMI package contains a
-fitting framework for combining multiple experimental inputs in a single
-optimization problem.
-
-This is an early release of code that is under intense development, with
-support for installation on Unix, Linux, and Macintosh machines.  The
-scope and documentation of the project will evolve rapidly, but we want
-to make the code available at the earliest possible date. Please make
-use of the software and provide feedback and suggestions for
-improvement, but please be patient and check back frequently for
-updates.
-
+Diffpy.cmi is a community-driven project that supports Unix, Linux, macOS, 
+and Windows platforms. It is designed to be used in Python scripts enabling 
+flexible scripting and automation for advanced and reproducible workflows. 
+Users are encouraged to leverage the software for their modeling needs and 
+to contribute feedback, use cases, and extensions through the project 
+community.
 
 
 .. figure:: ../../images/diffpycmi_screenshot.png
@@ -30,38 +23,135 @@ updates.
 
 Installation
 ============
+To install ``diffpy.cmi``, create a new conda environment or activate an existing environment and install the package from the conda-forge channel.
 
-Use of this software is subject to the conditions in
-software :doc:`LICENSE <license>`.
+.. code-block:: bash
 
-As of version 3.0 DiffPy-CMI is available for Linux and
-Mac as a collection of packages for Anaconda Python.  As
-a first step download and install **Anaconda for Python 3.7**
-from |anaconda-download|.
+    conda create -n diffpy.cmi-env
+    conda install -c conda-forge diffpy.cmi
+    conda activate diffpy.cmi-env
 
-.. note::
-   DiffPy-CMI is available from the "diffpy" channel of Anaconda packages. It requires Python 3.5 or later or 2.7. It is recommended to install it in a separate Anaconda environment, for example *py37* or other preferred python versions.
-   Make sure that *py37* environment is activated when working with DiffPy-CMI. ::
+To confirm that the installation was successful, type
 
-      conda create --name=py37 python=3.7
-      conda activate py37
+.. code-block:: bash
 
-Once Anaconda is ready, DiffPy-CMI can be installed from the "diffpy"
-channel of Anaconda packages as follows ::
+        cmi --version
 
-   conda config --add channels diffpy
-   conda install diffpy-cmi
+The output should print the latest version.
 
-The software distribution over Anaconda makes it easy to publish
-frequent software updates.  To update your installation later use ::
+If the above does not work, you can use ``pip`` to download and install the latest release from
+`Python Package Index <https://pypi.python.org>`_.
+To install using ``pip`` into your ``diffpy.cmi_env`` environment, type
 
-   conda update diffpy-cmi
+.. code-block:: bash
 
-If you don't want to use Anaconda you can
-:doc:`install DiffPy-CMI from sources <install>`.  Note that
-this method takes more time and requires more experience
-with the operating system.
+        pip install diffpy.cmi
 
+Pack and Profile Installation
+-----------------------------
+
+Use the `cmi` command-line interface to install and manage modular optional dependencies, known as `packs`,
+and to configure or execute user-defined workflows that combine multiple packs with optional post-installation steps,
+known as `profiles`. To use `cmi`, you can run the following example commands:
+
+Show available commands and options with,
+
+.. code-block:: bash
+
+    cmi -h
+
+List installed and available packs and profiles,
+
+.. code-block:: bash
+
+    cmi pack list
+    cmi profile list
+
+Show details of a specific pack or profile,
+
+.. code-block:: bash
+
+    cmi pack show <pack_name>
+    cmi profile show <profile_name>
+
+Install a pack or profile (by name or path),
+
+.. code-block:: bash
+
+    cmi install <pack_name>
+    cmi install <profile_name>
+    cmi install </absolute/path/to/profile>
+
+.. admonition:: Example installation
+
+    For example, to install the pack for PDF modeling, type,
+
+    .. code-block:: bash
+
+        cmi install pdf
+
+    To check to see if the pack was installed, type,
+
+    .. code-block:: bash
+
+        cmi pack list
+
+    The output should look something like this,
+
+    .. code-block:: bash
+
+        Installed:
+            - core
+            - pdf
+        Available to install:
+            - plotting
+            - tests
+            - docs
+
+
+Download examples
+-----------------
+
+To list and copy example scripts and data to your working directory, type,
+
+.. code-block:: bash
+
+    cmi example list
+    cmi example copy <example_name>
+
+.. admonition:: Example
+
+    For example, to see the example scripts for PDF fitting, type,
+
+    .. code-block:: bash
+
+        cmi example list
+
+    The output should look something like this,
+
+    .. code-block:: bash
+
+        ch03NiModelling
+        ch05Fit2Phase
+        ch06RefineCrystalStructureGen
+        ch07StructuralPhaseTransitions
+        ch08NPRefinement
+        ch11ClusterXYZ
+
+    To copy the example for bulk Ni PDF fitting, type,
+
+    .. code-block:: bash
+
+        cmi example copy ch03NiModelling
+
+    This will copy the example directory ``ch03NiModelling`` to your current working directory. Within this directory exists
+    the scripts and data to fit the bulk Ni PDF.
+
+    You can then run the fitting script with,
+
+    .. code-block:: bash
+
+        python ch03NiModelling/solutions/diffpy-cmi/fitBulkNi.py
 
 What next?
 ==========
@@ -78,11 +168,11 @@ What next?
 Tutorials
 =========
 
-* ADD2019_ school and conference --
+* Worked examples and experimental data from the book are freely available at our
+  `GitHub repository <https://github.com/Billingegroup/pdfttp_data>`_.
+
+* ADD2019 school and conference --
   https://github.com/diffpy/add2019-diffpy-cmi
-
-.. _ADD2019: https://workshops.ill.fr/event/133/page/32-home
-
 
 Documentation
 =============
@@ -101,8 +191,8 @@ at the links below.
 * |doc-libdiffpy|_ -- C++ library for calculation of PDF and other real-space
   quantities
 
-See :ref:`DiffPy-CMI contents <contents>` for a complete list
-of open-source libraries that are included in DiffPy-CMI and
+See :ref:`DiffPy.CMI contents <contents>` for a complete list
+of open-source libraries that are included in DiffPy.CMI and
 their respective project pages.
 
 
@@ -110,7 +200,7 @@ Reference
 =========
 
 If you use this software in a research work which leads to publication,
-we ask you to acknowledge the use of DiffPy-CMI by citing the following
+we ask you to acknowledge the use of DiffPy.CMI by citing the following
 paper:
 
 * |citeJuhasAca15|

--- a/products/diffpycmi/index.rst
+++ b/products/diffpycmi/index.rst
@@ -1,5 +1,5 @@
 ##########
-DiffPy.CMI
+|diffpycmi|
 ##########
 
 Diffpy.cmi is designed as an extensible complex modeling infrastructure. 
@@ -169,7 +169,7 @@ Tutorials
 =========
 
 * A step-by-step tutorial on using diffpy.cmi for PDF analysis is available at the documentation site for
-  ``DiffPy.CMI`` -- https://www.diffpy.org/diffpy.cmi/tutorials/index.html.
+  ``diffpy.cmi`` -- https://www.diffpy.org/diffpy.cmi/tutorials/index.html.
 
 * Worked examples and experimental data from the book *Atomic Pair Distribution Function Analysis: A Primer* are freely available at our
   `GitHub repository <https://github.com/Billingegroup/pdfttp_data>`_.
@@ -194,8 +194,8 @@ at the links below.
 * |doc-libdiffpy|_ -- C++ library for calculation of PDF and other real-space
   quantities
 
-See :ref:`DiffPy.CMI contents <contents>` for a complete list
-of open-source libraries that are included in DiffPy.CMI and
+See :ref:`diffpy.cmi contents <contents>` for a complete list
+of open-source libraries that are included in |diffpycmi| and
 their respective project pages.
 
 
@@ -203,7 +203,7 @@ Reference
 =========
 
 If you use this software in a research work which leads to publication,
-we ask you to acknowledge the use of DiffPy.CMI by citing the following
+we ask you to acknowledge the use of |diffpycmi| by citing the following
 paper:
 
 * |citeJuhasAca15|

--- a/products/diffpycmi/install.rst
+++ b/products/diffpycmi/install.rst
@@ -1,16 +1,16 @@
 .. highlight:: bash
 
-DiffPy.CMI installation from sources
+|diffpycmi| installation from sources
 ====================================
 
-Downloaded the most recent `DiffPy.CMI tarball
+Downloaded the most recent `diffpy.cmi tarball
 <https://github.com/diffpy/diffpy-release/releases/latest>`__
 and follow the steps below.
 
 1 Install system software
 ------------------------------------------------------------------------
 
-DiffPy.CMI requires the :ref:`system software dependencies <dependencies>`
+|diffpycmi| requires the :ref:`system software dependencies <dependencies>`
 which can be installed from command line using a suitable package manager.
 Here are installation commands for several supported systems.
 
@@ -43,7 +43,7 @@ Mac OS X
 For Mac OS X the system dependencies can be installed using the
 `MacPorts <https://www.macports.org>`_ software manager.  A similar
 package system `Homebrew <https://brew.sh>`_ works as well, but has
-been considerably less tested with DiffPy.CMI.
+been considerably less tested with |diffpycmi|.
 
 For best results with MacPorts follow these tips:
 
@@ -79,10 +79,10 @@ of ``.profile`` or ``.zshenv`` file in your HOME directory ::
     export PATH="/opt/local/bin:$PATH"
 
 
-2 Install DiffPy.CMI
+2 Install |diffpycmi|
 ------------------------------------------------------------------------
 
-Unzip the DiffPy.CMI tarball into a directory of your choice.
+Unzip the |diffpycmi| tarball into a directory of your choice.
 Execute the included :file:`install` script and follow the prompts. ::
 
    # replace VERSION to match the actual filename
@@ -143,7 +143,7 @@ the base diffpy_cmi directory and create the symbolic link with ::
 
 .. note::
 
-   The installation of DiffPy.CMI is entirely contained under the
+   The installation of |diffpycmi| is entirely contained under the
    expanded diffpy_cmi directory.  The software can be completely
    uninstalled by deleting that directory and removing the symbolic
    link.

--- a/products/diffpycmi/install.rst
+++ b/products/diffpycmi/install.rst
@@ -1,16 +1,16 @@
 .. highlight:: bash
 
-DiffPy-CMI installation from sources
+DiffPy.CMI installation from sources
 ====================================
 
-Downloaded the most recent `DiffPy-CMI tarball
+Downloaded the most recent `DiffPy.CMI tarball
 <https://github.com/diffpy/diffpy-release/releases/latest>`__
 and follow the steps below.
 
 1 Install system software
 ------------------------------------------------------------------------
 
-DiffPy-CMI requires the :ref:`system software dependencies <dependencies>`
+DiffPy.CMI requires the :ref:`system software dependencies <dependencies>`
 which can be installed from command line using a suitable package manager.
 Here are installation commands for several supported systems.
 
@@ -43,7 +43,7 @@ Mac OS X
 For Mac OS X the system dependencies can be installed using the
 `MacPorts <https://www.macports.org>`_ software manager.  A similar
 package system `Homebrew <https://brew.sh>`_ works as well, but has
-been considerably less tested with DiffPy-CMI.
+been considerably less tested with DiffPy.CMI.
 
 For best results with MacPorts follow these tips:
 
@@ -79,10 +79,10 @@ of ``.profile`` or ``.zshenv`` file in your HOME directory ::
     export PATH="/opt/local/bin:$PATH"
 
 
-2 Install DiffPy-CMI
+2 Install DiffPy.CMI
 ------------------------------------------------------------------------
 
-Unzip the DiffPy-CMI tarball into a directory of your choice.
+Unzip the DiffPy.CMI tarball into a directory of your choice.
 Execute the included :file:`install` script and follow the prompts. ::
 
    # replace VERSION to match the actual filename
@@ -143,7 +143,7 @@ the base diffpy_cmi directory and create the symbolic link with ::
 
 .. note::
 
-   The installation of DiffPy-CMI is entirely contained under the
+   The installation of DiffPy.CMI is entirely contained under the
    expanded diffpy_cmi directory.  The software can be completely
    uninstalled by deleting that directory and removing the symbolic
    link.

--- a/products/diffpycmi/license.rst
+++ b/products/diffpycmi/license.rst
@@ -1,6 +1,6 @@
-.. this page only contains the LICENSE text for DiffPy.CMI
+.. this page only contains the LICENSE text for |diffpycmi|
 
-.. title:: DiffPy.CMI License
+.. title:: |diffpycmi| License
 
 .. literalinclude:: LICENSE.txt
    :language: text

--- a/products/diffpycmi/license.rst
+++ b/products/diffpycmi/license.rst
@@ -1,6 +1,6 @@
-.. this page only contains the LICENSE text for DiffPy-CMI
+.. this page only contains the LICENSE text for DiffPy.CMI
 
-.. title:: DiffPy-CMI License
+.. title:: DiffPy.CMI License
 
 .. literalinclude:: LICENSE.txt
    :language: text

--- a/products/diffpycmi/updatesources.rst
+++ b/products/diffpycmi/updatesources.rst
@@ -48,4 +48,4 @@ cases, you could use option -n to display the build steps.
    other than system Python (e.g. the Enthought Python Distribution) it
    may be incompatible with the system boost library and the build may
    fail. To resolve the problem, you should rebuild the boost library
-   against Enthought Python and then rebuild all DiffPy.CMI modules.
+   against Enthought Python and then rebuild all diffpy.cmi modules.

--- a/products/diffpycmi/updatesources.rst
+++ b/products/diffpycmi/updatesources.rst
@@ -48,4 +48,4 @@ cases, you could use option -n to display the build steps.
    other than system Python (e.g. the Enthought Python Distribution) it
    may be incompatible with the system boost library and the build may
    fail. To resolve the problem, you should rebuild the boost library
-   against Enthought Python and then rebuild all DiffPy-CMI modules.
+   against Enthought Python and then rebuild all DiffPy.CMI modules.

--- a/products/mPDF.rst
+++ b/products/mPDF.rst
@@ -44,7 +44,7 @@ Installation
 The recommended way to install this package is through conda. For help installing conda,
 please visit |anaconda-download|.
 Once conda is installed, you can follow the simple steps below to install diffpy.mpdf.
-You will also install the full diffpy-cmi suite along the way.
+You will also install the full DiffPy.CMI suite along the way.
 
 *Step 1: Add the appropriate conda channels to your conda configuration.* ::
 
@@ -66,7 +66,7 @@ after the --name flag in the first command.
 
     conda install diffpy.mpdf
 
-Note that this will also install the full diffpy-cmi suite if it has not already been
+Note that this will also install the full DiffPy.CMI suite if it has not already been
 installed in this environment.
 
 *Alternative option: Install from the python package index.*

--- a/products/mPDF.rst
+++ b/products/mPDF.rst
@@ -44,7 +44,7 @@ Installation
 The recommended way to install this package is through conda. For help installing conda,
 please visit |anaconda-download|.
 Once conda is installed, you can follow the simple steps below to install diffpy.mpdf.
-You will also install the full DiffPy.CMI suite along the way.
+You will also install the full |diffpycmi| suite along the way.
 
 *Step 1: Add the appropriate conda channels to your conda configuration.* ::
 
@@ -66,7 +66,7 @@ after the --name flag in the first command.
 
     conda install diffpy.mpdf
 
-Note that this will also install the full DiffPy.CMI suite if it has not already been
+Note that this will also install the full |diffpycmi| suite if it has not already been
 installed in this environment.
 
 *Alternative option: Install from the python package index.*

--- a/products/xPDFsuite.rst
+++ b/products/xPDFsuite.rst
@@ -51,7 +51,7 @@ xPDFsuite is available for purchase for either academic or commercial applicatio
 .. _CTV_link: ctv-xpdfsuite_
 
 **Thank you for purchasing xPDFsuite. Funds we raise from sales help us to develop user interfaces and useful features on top of our
-free for academics and open source Diffpy products, such as Diffpy-CMI, PDFgetX3 and PDFgui.**
+free for academics and open source Diffpy products, such as DiffPy.CMI, PDFgetX3 and PDFgui.**
 
 **We hope you enjoy xPDFsuite and that it supercharges your PDF analyses.**  Please contact us with feedback and questions by
 emailing `Prof. Simon Billinge  <sb2896@columbia.edu>`_

--- a/products/xPDFsuite.rst
+++ b/products/xPDFsuite.rst
@@ -51,7 +51,7 @@ xPDFsuite is available for purchase for either academic or commercial applicatio
 .. _CTV_link: ctv-xpdfsuite_
 
 **Thank you for purchasing xPDFsuite. Funds we raise from sales help us to develop user interfaces and useful features on top of our
-free for academics and open source Diffpy products, such as DiffPy.CMI, PDFgetX3 and PDFgui.**
+free for academics and open source Diffpy products, such as |diffpycmi|, PDFgetX3 and PDFgui.**
 
 **We hope you enjoy xPDFsuite and that it supercharges your PDF analyses.**  Please contact us with feedback and questions by
 emailing `Prof. Simon Billinge  <sb2896@columbia.edu>`_

--- a/products/xinterpdf.rst
+++ b/products/xinterpdf.rst
@@ -4,7 +4,7 @@ xINTERPDF
 
 xINTERPDF is a Python GUI program for analyzing X-ray pair distribution
 function (PDF) data of organic compounds collected at synchrotron and/or
-laboratory X-ray sources. It uses DiffPy.CMI as a backend for simulation
+laboratory X-ray sources. It uses |diffpycmi| as a backend for simulation
 of PDFs.
 
 Currently it supports:
@@ -39,7 +39,7 @@ The xINTERPDF package requires Python 2.7 and the following dependency packages:
 * ``SciPy`` - Scientific libraries for Python
 * ``matplotlib`` - Python plotting library
 * ``Scikit-Learn`` - Python machine learning library; its PCA module is called.
-* ``DiffPy.CMI`` - Versatile Python packages for simulation of atomic pair distribution functions
+* ``diffpy.cmi`` - Versatile Python packages for simulation of atomic pair distribution functions
 * ``Tkinter`` - Python default library for creation of graphical user interface
 
 See the :doc:`xINTERPDF license <xinterpdflicense>` for terms and conditions of use.

--- a/products/xinterpdf.rst
+++ b/products/xinterpdf.rst
@@ -4,7 +4,7 @@ xINTERPDF
 
 xINTERPDF is a Python GUI program for analyzing X-ray pair distribution
 function (PDF) data of organic compounds collected at synchrotron and/or
-laboratory X-ray sources. It uses DiffPy-CMI as a backend for simulation
+laboratory X-ray sources. It uses DiffPy.CMI as a backend for simulation
 of PDFs.
 
 Currently it supports:
@@ -39,7 +39,7 @@ The xINTERPDF package requires Python 2.7 and the following dependency packages:
 * ``SciPy`` - Scientific libraries for Python
 * ``matplotlib`` - Python plotting library
 * ``Scikit-Learn`` - Python machine learning library; its PCA module is called.
-* ``diffpy-cmi`` - Versatile Python packages for simulation of atomic pair distribution functions
+* ``DiffPy.CMI`` - Versatile Python packages for simulation of atomic pair distribution functions
 * ``Tkinter`` - Python default library for creation of graphical user interface
 
 See the :doc:`xINTERPDF license <xinterpdflicense>` for terms and conditions of use.

--- a/publications.rst
+++ b/publications.rst
@@ -24,7 +24,7 @@ Please cite us if our software has been used in your research.
 
 
 
-Publications using DiffPy.CMI
+Publications using |diffpycmi|
 =============================
 
 The following papers made use of DiffPy developed software for analysis

--- a/publications.rst
+++ b/publications.rst
@@ -24,7 +24,7 @@ Please cite us if our software has been used in your research.
 
 
 
-Publications using DiffPy-CMI
+Publications using DiffPy.CMI
 =============================
 
 The following papers made use of DiffPy developed software for analysis

--- a/static_root/doc/pdfgetx/2.0.0/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.0.0/_sources/tutorial.rst.txt
@@ -645,14 +645,14 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy-CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::
 
-   $ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+   $ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
    $ conda activate nbcmi
    $ python -m easy_install path/to/diffpy.pdfgetx-VERSION.egg
 

--- a/static_root/doc/pdfgetx/2.0.0/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.0.0/_sources/tutorial.rst.txt
@@ -645,9 +645,9 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`diffpy.cmi <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::

--- a/static_root/doc/pdfgetx/2.0.0/tutorial.html
+++ b/static_root/doc/pdfgetx/2.0.0/tutorial.html
@@ -644,9 +644,9 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy-CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>

--- a/static_root/doc/pdfgetx/2.0.0/tutorial.html
+++ b/static_root/doc/pdfgetx/2.0.0/tutorial.html
@@ -644,9 +644,9 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">diffpy.cmi</a>,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>

--- a/static_root/doc/pdfgetx/2.1.0/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.1.0/_sources/tutorial.rst.txt
@@ -644,9 +644,9 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`diffpy.cmi <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::

--- a/static_root/doc/pdfgetx/2.1.0/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.1.0/_sources/tutorial.rst.txt
@@ -644,14 +644,14 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy-CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::
 
-   $ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+   $ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
    $ conda activate nbcmi
    $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 

--- a/static_root/doc/pdfgetx/2.1.0/tutorial.html
+++ b/static_root/doc/pdfgetx/2.1.0/tutorial.html
@@ -646,9 +646,9 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">diffpy.cmi</a>,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>

--- a/static_root/doc/pdfgetx/2.1.0/tutorial.html
+++ b/static_root/doc/pdfgetx/2.1.0/tutorial.html
@@ -646,13 +646,13 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy-CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
 $ conda activate nbcmi
 $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 </pre></div>

--- a/static_root/doc/pdfgetx/2.1.1/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.1.1/_sources/tutorial.rst.txt
@@ -644,9 +644,9 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`diffpy.cmi <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::

--- a/static_root/doc/pdfgetx/2.1.1/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.1.1/_sources/tutorial.rst.txt
@@ -644,14 +644,14 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy-CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::
 
-   $ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+   $ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
    $ conda activate nbcmi
    $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 

--- a/static_root/doc/pdfgetx/2.1.1/tutorial.html
+++ b/static_root/doc/pdfgetx/2.1.1/tutorial.html
@@ -646,9 +646,9 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">diffpy.cmi</a>,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>

--- a/static_root/doc/pdfgetx/2.1.1/tutorial.html
+++ b/static_root/doc/pdfgetx/2.1.1/tutorial.html
@@ -646,13 +646,13 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy-CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
 $ conda activate nbcmi
 $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 </pre></div>

--- a/static_root/doc/pdfgetx/2.1.2/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.1.2/_sources/tutorial.rst.txt
@@ -644,9 +644,9 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`diffpy.cmi <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::

--- a/static_root/doc/pdfgetx/2.1.2/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.1.2/_sources/tutorial.rst.txt
@@ -644,14 +644,14 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy-CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::
 
-   $ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+   $ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
    $ conda activate nbcmi
    $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 

--- a/static_root/doc/pdfgetx/2.1.2/tutorial.html
+++ b/static_root/doc/pdfgetx/2.1.2/tutorial.html
@@ -646,9 +646,9 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">diffpy.cmi</a>,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>

--- a/static_root/doc/pdfgetx/2.1.2/tutorial.html
+++ b/static_root/doc/pdfgetx/2.1.2/tutorial.html
@@ -646,13 +646,13 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy-CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
 $ conda activate nbcmi
 $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 </pre></div>

--- a/static_root/doc/pdfgetx/2.2.0/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.2.0/_sources/tutorial.rst.txt
@@ -644,9 +644,9 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`diffpy.cmi <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::

--- a/static_root/doc/pdfgetx/2.2.0/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.2.0/_sources/tutorial.rst.txt
@@ -644,14 +644,14 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy-CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::
 
-   $ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+   $ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
    $ conda activate nbcmi
    $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 

--- a/static_root/doc/pdfgetx/2.2.0/tutorial.html
+++ b/static_root/doc/pdfgetx/2.2.0/tutorial.html
@@ -646,9 +646,9 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">diffpy.cmi</a>,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>

--- a/static_root/doc/pdfgetx/2.2.0/tutorial.html
+++ b/static_root/doc/pdfgetx/2.2.0/tutorial.html
@@ -646,13 +646,13 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy-CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
 $ conda activate nbcmi
 $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 </pre></div>

--- a/static_root/doc/pdfgetx/2.2.1/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.2.1/_sources/tutorial.rst.txt
@@ -644,9 +644,9 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`diffpy.cmi <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::

--- a/static_root/doc/pdfgetx/2.2.1/_sources/tutorial.rst.txt
+++ b/static_root/doc/pdfgetx/2.2.1/_sources/tutorial.rst.txt
@@ -644,14 +644,14 @@ the zero offset may change for different samples.
 
 This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-`DiffPy-CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
+`DiffPy.CMI <https://www.diffpy.org/products/diffpycmi/index.html>`__,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use `Anaconda Python`_ and set up a dedicated
 Anaconda environment *nbcmi* for this tutorial.
 This can be accomplished using the following steps::
 
-   $ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+   $ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
    $ conda activate nbcmi
    $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 

--- a/static_root/doc/pdfgetx/2.2.1/tutorial.html
+++ b/static_root/doc/pdfgetx/2.2.1/tutorial.html
@@ -646,9 +646,9 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">diffpy.cmi</a>,
 which is not yet available for Windows.
-If DiffPy.CMI is not yet installed,
+If diffpy.cmi is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>

--- a/static_root/doc/pdfgetx/2.2.1/tutorial.html
+++ b/static_root/doc/pdfgetx/2.2.1/tutorial.html
@@ -646,13 +646,13 @@ a full-fledged PDF refinement in case
 the zero offset may change for different samples.</p>
 <p>This tutorial requires either Linux or Mac OS X platforms,
 because the PDF fitting is conducted with
-<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy-CMI</a>,
+<a class="reference external" href="https://www.diffpy.org/products/diffpycmi/index.html">DiffPy.CMI</a>,
 which is not yet available for Windows.
-If DiffPy-CMI is not yet installed,
+If DiffPy.CMI is not yet installed,
 we recommend to use <a class="reference external" href="https://www.anaconda.com/download">Anaconda Python</a> and set up a dedicated
 Anaconda environment <em>nbcmi</em> for this tutorial.
 This can be accomplished using the following steps:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy-cmi
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ conda create -n nbcmi -c diffpy python=2 diffpy.cmi
 $ conda activate nbcmi
 $ pip install path/to/diffpy.pdfgetx-VERSION.whl
 </pre></div>


### PR DESCRIPTION
I went through and manually changed the name from diffpy-cmi to diffpy.cmi. I've also updated installation instructions to match the current docs. documentation built successfully on local